### PR TITLE
Block command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "ternoa-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod subternxt;
 use crate::subternxt::constants::{
-    ALPHANET_CHAIN_URL, MAINNET_CHAIN_URL, ALPHANET_DICTIONARY_URL, MAINNET_DICTIONARY_URL, MAINNET_INDEXER_URL,
+    ALPHANET_CHAIN_URL, MAINNET_CHAIN_URL, ALPHANET_DICTIONARY_URL, MAINNET_DICTIONARY_URL, ALPHANET_INDEXER_URL, MAINNET_INDEXER_URL,
 };
 use crate::subternxt::{
     counts::{get_active_validators, get_nft_count, get_nominator_count, get_total_validators},
@@ -92,7 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //Parse commandline
     let cli = Cli::parse();
 
-    let (network, dictionary_url) = if let Some(ref chain_name) = cli.network {
+    let (network, indexer_url, dictionary_url) = if let Some(ref chain_name) = cli.network {
         println!("Network selected is: {}", chain_name);
 
         let chain_name = chain_name.to_lowercase();
@@ -102,15 +102,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             _ => &chain_name,
         };
 
+        let indexer_url = match chain_name.as_str() {
+            "mainnet" => MAINNET_INDEXER_URL,
+            "alphanet" => ALPHANET_INDEXER_URL,
+            _ => &chain_name,
+        };
+
         let dictionary_url = match chain_name.as_str() {
             "mainnet" => MAINNET_DICTIONARY_URL,
             "alphanet" => ALPHANET_DICTIONARY_URL,
             _ => &chain_name,
         };
 
-        (chain_url.to_string(), dictionary_url.to_string())
+        (chain_url.to_string(), indexer_url.to_string(), dictionary_url.to_string())
     } else {
-        (MAINNET_CHAIN_URL.to_string(), MAINNET_DICTIONARY_URL.to_string())
+        (MAINNET_CHAIN_URL.to_string(), MAINNET_INDEXER_URL.to_string(), MAINNET_DICTIONARY_URL.to_string())
     };
 
     match &cli.command {
@@ -152,12 +158,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("Active validators = {} ", active_validators);
             }
             CountParameter::ActiveWallets => {
-                let active_wallets = get_active_wallets(MAINNET_INDEXER_URL.to_string()).await?;
+                let active_wallets = get_active_wallets(indexer_url).await?;
                 println!("Active wallets on the Mainnet = {:?} ", active_wallets);
             }
             CountParameter::TotalTransactions => {
                 let total_transactions =
-                    get_total_transactions(MAINNET_DICTIONARY_URL.to_string()).await?;
+                    get_total_transactions(dictionary_url).await?;
                 println!(
                     "Total transactions on the Mainnet = {:?} ",
                     total_transactions

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 mod subternxt;
 use crate::subternxt::constants::{
-    ALPHANET_CHAIN_URL, MAINNET_CHAIN_URL, MAINNET_DICTIONARY_URL, MAINNET_INDEXER_URL,
+    ALPHANET_CHAIN_URL, MAINNET_CHAIN_URL, ALPHANET_DICTIONARY_URL, MAINNET_DICTIONARY_URL, MAINNET_INDEXER_URL,
 };
 use crate::subternxt::{
     counts::{get_active_validators, get_nft_count, get_nominator_count, get_total_validators},
-    graphql::{active_wallets::get_active_wallets, total_transactions::get_total_transactions},
+    graphql::{active_wallets::get_active_wallets, first_item_block_id::get_first_item_block_id, total_transactions::get_total_transactions},
     state::get_current_era,
 };
 
@@ -26,10 +26,29 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Provides block ID for major events from Ternoa chain
+    Block(Block),
     /// Provides the current state of the parameter from Ternoa chain
     State(State),
     /// Provides a count of the parameter from Ternoa chain
     Count(Count),
+}
+
+#[derive(Args)]
+struct Block {
+    /// The parameter for which block is requested
+    #[command(subcommand)]
+    block_parameter: BlockParameter,
+}
+
+#[derive(Subcommand)]
+enum BlockParameter {
+    /// Returns the block ID of the first NFT minted
+    FirstNFT,
+    /// Returns the block ID of the first Collection minted
+    FirstCollection,
+    /// Returns the block ID of the first Marketplace created
+    FirstMarketplace
 }
 
 #[derive(Args)]
@@ -72,20 +91,43 @@ enum CountParameter {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //Parse commandline
     let cli = Cli::parse();
-    let network: String = if let Some(chain_name) = cli.network {
+
+    let (network, dictionary_url) = if let Some(ref chain_name) = cli.network {
         println!("Network selected is: {}", chain_name);
-        if chain_name.to_lowercase() == "mainnet" {
-            MAINNET_CHAIN_URL.to_string()
-        } else if chain_name.to_lowercase() == "alphanet" {
-            ALPHANET_CHAIN_URL.to_string()
-        } else {
-            chain_name
-        }
+
+        let chain_name = chain_name.to_lowercase();
+        let chain_url = match chain_name.as_str() {
+            "mainnet" => MAINNET_CHAIN_URL,
+            "alphanet" => ALPHANET_CHAIN_URL,
+            _ => &chain_name,
+        };
+
+        let dictionary_url = match chain_name.as_str() {
+            "mainnet" => MAINNET_DICTIONARY_URL,
+            "alphanet" => ALPHANET_DICTIONARY_URL,
+            _ => &chain_name,
+        };
+
+        (chain_url.to_string(), dictionary_url.to_string())
     } else {
-        MAINNET_CHAIN_URL.to_string()
+        (MAINNET_CHAIN_URL.to_string(), MAINNET_DICTIONARY_URL.to_string())
     };
 
     match &cli.command {
+        Some(Commands::Block(name)) => match name.block_parameter {
+            BlockParameter::FirstNFT => {
+                let block_id = get_first_item_block_id(dictionary_url, "NFTCreated".to_string()).await?;
+                println!("First NFT minted on block {} ", block_id);
+            },
+            BlockParameter::FirstCollection => {
+                let block_id = get_first_item_block_id(dictionary_url, "CollectionCreated".to_string()).await?;
+                println!("First Collection minted on block {} ", block_id);
+            },
+            BlockParameter::FirstMarketplace => {
+                let block_id = get_first_item_block_id(dictionary_url, "MarketplaceCreated".to_string()).await?;
+                println!("First Marketplace created on block {} ", block_id);
+            }
+        },
         Some(Commands::State(name)) => match name.state_parameter {
             StateParameter::CurrentEra => {
                 let current_era = get_current_era(network).await?;

--- a/src/subternxt/constants.rs
+++ b/src/subternxt/constants.rs
@@ -1,5 +1,6 @@
 pub const MAINNET_CHAIN_URL: &str = "wss://mainnet.ternoa.network:443";
 pub const ALPHANET_CHAIN_URL: &str = "wss://alphanet.ternoa.com:443";
-pub const MAINNET_INDEXER_URL: &str = "https://indexer-mainnet.ternoa.network/";
+pub const MAINNET_INDEXER_URL: &str = "https://indexer-mainnet.ternoa.network";
+pub const ALPHANET_INDEXER_URL: &str = "https://indexer-alphanet.ternoa.dev";
 pub const MAINNET_DICTIONARY_URL: &str = "https://dictionary-mainnet.ternoa.network";
 pub const ALPHANET_DICTIONARY_URL: &str = "https://dictionary-alphanet.ternoa.dev";

--- a/src/subternxt/constants.rs
+++ b/src/subternxt/constants.rs
@@ -2,3 +2,4 @@ pub const MAINNET_CHAIN_URL: &str = "wss://mainnet.ternoa.network:443";
 pub const ALPHANET_CHAIN_URL: &str = "wss://alphanet.ternoa.com:443";
 pub const MAINNET_INDEXER_URL: &str = "https://indexer-mainnet.ternoa.network/";
 pub const MAINNET_DICTIONARY_URL: &str = "https://dictionary-mainnet.ternoa.network";
+pub const ALPHANET_DICTIONARY_URL: &str = "https://dictionary-alphanet.ternoa.dev";

--- a/src/subternxt/graphql/active_wallets.rs
+++ b/src/subternxt/graphql/active_wallets.rs
@@ -10,12 +10,11 @@ use std::error::Error;
 )]
 pub struct AccountEntities;
 
-pub async fn get_active_wallets(network: String) -> Result<i64, Box<dyn Error>> {
-    println!("Get active wallets: This feature is only available for the mainnet");
+pub async fn get_active_wallets(url: String) -> Result<i64, Box<dyn Error>> {
     let request_body = AccountEntities::build_query(account_entities::Variables);
 
     let client = reqwest::Client::new();
-    let res = client.post(network).json(&request_body).send().await?;
+    let res = client.post(url).json(&request_body).send().await?;
     let response_body: Response<account_entities::ResponseData> = res.json().await?;
 
     let total_count = if let Some(ref response_data) = response_body.data {

--- a/src/subternxt/graphql/first_item_block_id.rs
+++ b/src/subternxt/graphql/first_item_block_id.rs
@@ -1,0 +1,36 @@
+use graphql_client::{GraphQLQuery, Response};
+use reqwest::Client;
+use std::error::Error;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/subternxt/graphql/schemas/mainnet_dictionary_schema.json",
+    query_path = "src/subternxt/graphql/queries/first_item_block_id.graphql",
+    response_derives = "Debug"
+)]
+pub struct GetFirstItemBlockId;
+
+pub async fn get_first_item_block_id(url: String, event: String) -> Result<i64, Box<dyn Error>> {
+    let client = Client::new();
+    let request_body = GetFirstItemBlockId::build_query(get_first_item_block_id::Variables {
+        event,
+      });
+    let response = client.post(url).json(&request_body).send().await?;
+    let response_body: Response<get_first_item_block_id::ResponseData> = response.json().await?;
+
+    let block_id = match response_body.data {
+        Some(ref data) => {
+            match data.events {
+                Some(ref events) => {
+                    match &events.nodes[0] {
+                        Some(event) => event.block_id.parse::<i64>(),
+                        None => Ok(0),
+                    }
+                }
+                None => Ok(0),
+            }
+        }
+        None => Ok(0),
+    }?;
+    Ok(block_id)
+}

--- a/src/subternxt/graphql/mod.rs
+++ b/src/subternxt/graphql/mod.rs
@@ -1,2 +1,3 @@
 pub mod active_wallets;
+pub mod first_item_block_id;
 pub mod total_transactions;

--- a/src/subternxt/graphql/queries/first_item_block_id.graphql
+++ b/src/subternxt/graphql/queries/first_item_block_id.graphql
@@ -1,0 +1,13 @@
+query GetFirstItemBlockId($event: String!) {
+  events(
+    first: 1
+    orderBy: [BLOCK_HEIGHT_ASC, EVENT_INDEX_ASC]
+    filter: {
+        call: { equalTo: $event }
+    }
+  ) {
+    nodes {
+      blockId
+    }
+  }
+}

--- a/src/subternxt/graphql/total_transactions.rs
+++ b/src/subternxt/graphql/total_transactions.rs
@@ -10,12 +10,11 @@ use std::error::Error;
 )]
 pub struct TotalTransactions;
 
-pub async fn get_total_transactions(network: String) -> Result<i64, Box<dyn Error>> {
-    println!("Get total transactions: This feature is only available for the mainnet");
+pub async fn get_total_transactions(url: String) -> Result<i64, Box<dyn Error>> {
     let request_body = TotalTransactions::build_query(total_transactions::Variables);
 
     let client = reqwest::Client::new();
-    let res = client.post(network).json(&request_body).send().await?;
+    let res = client.post(url).json(&request_body).send().await?;
     let response_body: Response<total_transactions::ResponseData> = res.json().await?;
     //println!("{:?}", response_body.data);
     let total_count = if let Some(ref response_data) = response_body.data {


### PR DESCRIPTION
## Description

Some major blocks will last forever, in particular the ones where first items were minted (e.g. 1st NFT minted, 1st Collection minted). The new block command aims to return those block IDs depending of the parameter used.

## Usage

```bash
$ ternoa-cli block first-nft
> First NFT minted on block 1102830


$ ternoa-cli block first-marketplace
> First Marketplace created on block 1232305


$ ternoa-cli -n alphanet block first-collection
> Network selected is: alphanet
> First Collection minted on block 1108069
```